### PR TITLE
fix: add line breaks when task content is too long

### DIFF
--- a/src/pages/task/[id].tsx
+++ b/src/pages/task/[id].tsx
@@ -126,7 +126,7 @@ const TaskDetail = ({ task }: TaskDetailProps) => {
                 </div>
             </div>
 
-            <pre className="overflow-y-scroll whitespace-pre-wrap px-0.5 py-4">{task.body}</pre>
+            <pre className="overflow-y-scroll whitespace-pre-wrap break-all px-0.5 py-4">{task.body}</pre>
 
             <Suspense>
                 <EditTaskModal isOpen={isOpen} task={task} onClose={toggleModal} />


### PR DESCRIPTION
Add line breaks when the task detail page content is too long.

Fixes #22 